### PR TITLE
Powder chest highlight

### DIFF
--- a/src/main/java/mrfast/sbt/config/categories/MiningConfig.kt
+++ b/src/main/java/mrfast/sbt/config/categories/MiningConfig.kt
@@ -84,4 +84,13 @@ object MiningConfig : Config() {
         parentName = "Forge Flipper Overlay"
     )
     var forgeFlipperMaxHotm = 10
+
+    @ConfigProperty(
+        type = ConfigType.TOGGLE,
+        name = "Powder Chest Highlight",
+        description = "Highlights powder chests in the Crystal hollows Mines through walls, including a timer before despawn.",
+        category = "Mining",
+        subcategory = "Render"
+    )
+    var PowderChestESP = true
 }

--- a/src/main/java/mrfast/sbt/features/mining/crystal/PowderChestHighLight.kt
+++ b/src/main/java/mrfast/sbt/features/mining/crystal/PowderChestHighLight.kt
@@ -1,0 +1,65 @@
+package mrfast.sbt.features.mining.crystal
+
+import mrfast.sbt.SkyblockTweaks
+import mrfast.sbt.config.categories.MiningConfig
+import mrfast.sbt.managers.LocationManager
+import mrfast.sbt.utils.RenderUtils
+
+import net.minecraft.tileentity.TileEntityChest
+import net.minecraft.util.BlockPos
+import net.minecraftforge.client.event.RenderWorldLastEvent
+import net.minecraftforge.event.world.WorldEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.common.MinecraftForge
+
+import java.awt.Color
+import java.util.concurrent.ConcurrentHashMap
+
+@SkyblockTweaks.EventComponent
+object PowderChestHighlighter {
+
+    private val chestSpawns = ConcurrentHashMap<BlockPos, Long>()
+    private const val CHEST_LIFETIME_MS = 60000L // 60 seconds
+
+    init {
+        MinecraftForge.EVENT_BUS.register(this)
+    }
+
+    @SubscribeEvent
+    fun onRenderWorld(event: RenderWorldLastEvent) {
+        if (!MiningConfig.PowderChestESP) return
+
+        val mc = net.minecraft.client.Minecraft.getMinecraft()
+        val world = mc.theWorld ?: return
+        val now = System.currentTimeMillis()
+
+        for (tile in world.loadedTileEntityList) {
+            if (tile is TileEntityChest) {
+                val pos = tile.pos
+                chestSpawns.putIfAbsent(pos, now)
+            }
+        }
+
+        chestSpawns.entries.removeIf { (pos, spawnTime) ->
+            val tileEntity = world.getTileEntity(pos)
+            if (tileEntity !is TileEntityChest) {
+                true
+            } else if (now - spawnTime > CHEST_LIFETIME_MS) {
+                true
+            } else {
+                RenderUtils.drawSpecialBB(pos, Color(255, 255, 0, 128), event.partialTicks)
+                false
+            }
+        }
+    }
+
+    @SubscribeEvent
+    fun onWorldChange(event: WorldEvent.Load) {
+        chestSpawns.clear()
+    }
+
+    private fun shouldReturn(): Boolean {
+        val isNotInCrystalHollows = !LocationManager.currentArea.contains("Crystal Hollows", ignoreCase = true)
+        return !LocationManager.inSkyblock || isNotInCrystalHollows
+    }
+}


### PR DESCRIPTION
Add Powder Chest Highlight feature for Crystal Hollows

- Implemented functionality to highlight powder chests through walls.
- Added a despawn timer to indicate when chests will disappear.
- Integrated the feature with `MiningConfig` for toggling.
- Ensured highlights are cleared on world change.